### PR TITLE
- add go and node to the devcontainer features

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,15 @@
 			"username": "vscode"
 		},
 		"ghcr.io/stuartleeks/dev-container-features/shell-history:0": {},
-        "ghcr.io/va-h/devcontainers-features/uv:1": {}
+        "ghcr.io/va-h/devcontainers-features/uv:1": {},
+		"ghcr.io/dhoeric/features/trivy:1": {},
+		"ghcr.io/devcontainers/features/go:1": {
+		"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/node:1": {
+		"nodeGypDependencies": true,
+		"version": "lts"
+		}
 	},
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,13 +25,15 @@
 		},
 		"ghcr.io/stuartleeks/dev-container-features/shell-history:0": {},
         "ghcr.io/va-h/devcontainers-features/uv:1": {},
-		"ghcr.io/dhoeric/features/trivy:1": {},
+		"ghcr.io/dhoeric/features/trivy:1": {
+			"version": "0.63.0"
+		},
 		"ghcr.io/devcontainers/features/go:1": {
-		"version": "latest"
+			"version": "1.24.4"
 		},
 		"ghcr.io/devcontainers/features/node:1": {
-		"nodeGypDependencies": true,
-		"version": "lts"
+			"nodeGypDependencies": true,
+			"version": "22"
 		}
 	},
 	// Configure tool-specific properties.

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -14,14 +14,16 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$bashrc_path"
 cat $HOME/.zshrc
 export PATH="$HOME/.local/bin:$PATH"
 
-# Install Trivy
-export TRIVY_VERSION=0.63.0
-wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb
-sudo dpkg -i trivy_${TRIVY_VERSION}_Linux-64bit.deb
-rm trivy_${TRIVY_VERSION}_Linux-64bit.deb
-
 # Install Trivy plugins
 trivy plugin install mcp
 
 # Install CVE Search
 cd mcp_servers/cve-search_mcp && uv sync
+
+# Install vexctl
+go install github.com/openvex/vexctl@latest
+
+# Install vexdoc MCP Server
+npm install -g https://github.com/rosstaco/vexdoc-mcp/releases/download/0.0.1-pre-release/vexdoc-mcp-0.0.1.tgz
+
+echo "✅ Post-create script completed successfully."

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -18,10 +18,12 @@ export PATH="$HOME/.local/bin:$PATH"
 trivy plugin install mcp
 
 # Install CVE Search
-cd mcp_servers/cve-search_mcp && uv sync
+pushd mcp_servers/cve-search_mcp || exit
+uv sync
+popd || exit
 
 # Install vexctl
-go install github.com/openvex/vexctl@latest
+go install github.com/openvex/vexctl@v0.3.0
 
 # Install vexdoc MCP Server
 npm install -g https://github.com/rosstaco/vexdoc-mcp/releases/download/0.0.1-pre-release/vexdoc-mcp-0.0.1.tgz

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -12,6 +12,13 @@
             "url": "http://localhost:8080/sse",
 
         },
+        "vexdoc-mcp": {
+            "type": "stdio",
+            "command": "npx",
+            "args": [
+                "vexdoc-mcp"
+            ]
+        },
         "cve-search_mcp": {
             "type": "stdio",
             "command": "uv",

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This automated workflow generates three comprehensive security deliverables:
 
 1. **📄 Summary** - Executive overview of critical findings
 2. **📋 Security Report** - Detailed technical analysis with remediation guidance  
-3. **🔒 VEX Document** - Industry-standard exploitability determinations
+3. **🔒 VEX Document** - Industry-standard OpenVEX-compliant exploitability determinations generated using the VEX Document MCP Server
 
 **📁 Example Reports**: [docs/security/reports/](docs/security/reports/) | **📖 Full Instructions**: [.github/instructions/vex.instructions.md](.github/instructions/vex.instructions.md)
 
@@ -60,7 +60,7 @@ Systematic manual review discovering application-specific vulnerabilities beyond
 - Custom code security patterns
 
 ### 4. 📋 Comprehensive Documentation
-Generate three industry-standard deliverables with complete technical analysis and evidence-based conclusions.
+Generate three industry-standard deliverables with complete technical analysis and evidence-based conclusions. VEX documents are created using the VEX Document MCP Server to ensure OpenVEX compliance and standardized vulnerability communication.
 
 ## Quick Start
 
@@ -89,7 +89,7 @@ All deliverables automatically saved to: `docs/security/reports/[report-name]/`
 **🎯 Evidence-Based Analysis**: Every vulnerability determination backed by concrete technical proof and detailed reasoning  
 **🔍 Beyond CVE Scanning**: Discovers application-specific vulnerabilities through systematic OWASP Top 10 review  
 **📊 Risk-Based Prioritization**: Focus security resources on vulnerabilities that pose actual threat in your environment  
-**📋 Industry Standards**: OpenVEX-compliant documents enabling transparent vulnerability communication across teams and vendors  
+**📋 Industry Standards**: OpenVEX-compliant documents generated using the VEX Document MCP Server, enabling transparent vulnerability communication across teams and vendors  
 **🔬 Technical Rigor**: Exploitability analysis performed with penetration testing-level depth and documentation  
 **⚡ Automation with Intelligence**: Combines automated scanning tools with human-level security analysis reasoning
 
@@ -111,10 +111,21 @@ cd mcp_servers/trivy
   "mcp": {
     "servers": {
       "Trivy MCP": {
+        "type": "stdio",
         "command": "trivy",
         "args": ["mcp"]
       },
+      "Trivy MCP SSE": {
+        "type": "sse",
+        "url": "http://localhost:8080/sse"
+      },
+      "vexdoc-mcp": {
+        "type": "stdio",
+        "command": "npx",
+        "args": ["vexdoc-mcp"]
+      },
       "cve-search_mcp": {
+        "type": "stdio",
         "command": "uv",
         "args": ["--directory", "mcp_servers/cve-search_mcp", "run", "main.py"]
       }
@@ -131,5 +142,6 @@ cd mcp_servers/trivy
 
 ## Links
 - [Trivy MCP](https://github.com/aquasecurity/trivy-mcp)
+- [VEX Document MCP Server](https://github.com/rosstaco/vexdoc-mcp)
 - [CVE Search MCP](https://github.com/roadwy/cve-search_mcp) 
 - [Vulpy Test App](https://github.com/fportantier/vulpy)


### PR DESCRIPTION
- moved trivy from the post_create.sh to devcontainer features for multi arch support (e.g. macOS)
- Added vexctl and vexdoc mcp server install to the post_create.sh